### PR TITLE
Prepare release v0.1.1 (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 - 2022-07-26
+### Fixed
+- ([#54]) Preserve top-level comments in files when updating imports.
+- Parse generics syntax introduced in Go 1.18.
+
+  [#54]: https://github.com/uber-go/gopatch/issues/54
+
+Thanks to @breml for their contribution to this release.
+
 ## 0.1.0 - 2021-08-19
 Starting this release, we will include pre-built binaries of gopatch for
 different systems.

--- a/testdata/generic_instantiation
+++ b/testdata/generic_instantiation
@@ -1,0 +1,26 @@
+Test that we can parse generic function instantiation in patches.
+
+-- foo_to_bar.patch --
+@@
+var T, v expression
+@@
+-foo[T](v)
++bar[T](v)
+
+-- a.in.go --
+package a
+
+func baz() {
+	foo[int](42)
+	foo[[]byte]([]byte("hello"))
+	foo[List[int]](nil)
+}
+
+-- a.out.go --
+package a
+
+func baz() {
+	bar[int](42)
+	bar[[]byte]([]byte("hello"))
+	bar[List[int]](nil)
+}

--- a/testdata/generics_in_src
+++ b/testdata/generics_in_src
@@ -1,0 +1,34 @@
+Test that we can parse generics syntax in source files.
+
+-- foo_to_bar.patch --
+@@
+@@
+-foo
++bar
+
+-- a.in.go --
+package a
+
+import "fmt"
+
+func foo[T any](x T) {
+	fmt.Println(x)
+}
+
+func baz() {
+	foo[int](42)
+}
+
+-- a.out.go --
+package a
+
+import "fmt"
+
+func bar[T any](x T) {
+	fmt.Println(x)
+}
+
+func baz() {
+	bar[int](42)
+}
+


### PR DESCRIPTION
Prepare a new release of gopatch with a fix for #54.

This will release a binary compiled against Go 1.18,
so it will be able to parse generics syntax.
Verify that we're able to parse generics syntax with two new integration
tests.