### PR TITLE
Fix #82 Elision: match 1 or more returned types

### DIFF
--- a/internal/engine/pos.go
+++ b/internal/engine/pos.go
@@ -59,6 +59,14 @@ func (m PosMatcher) Match(v reflect.Value, d data.Data, _ Region) (data.Data, bo
 	if ok {
 		d = pushPosMatch(m.Fset, d, m.Pos, got)
 	}
+	// we are expecting a ( ) but there isn't any
+	// we continue to the next matcher and return match as true
+	// Issue: when can that be wrong i.e. when can that not be a match
+	// Reservation: we should return true only if sliceMatcher is
+	// between these two () i.e. (...)
+	if !got.IsValid() && m.Pos.IsValid() {
+		return d, true
+	}
 	return d, ok
 }
 

--- a/testdata/patch/return_elision.patch
+++ b/testdata/patch/return_elision.patch
@@ -1,0 +1,8 @@
+# Elision on function return argument
+@@
+@@
+ func f() (...) {
+- fmt.Println("")
++ fmt.Println("hello")
+  ...
+ }

--- a/testdata/test_files/test_return_elision.go
+++ b/testdata/test_files/test_return_elision.go
@@ -1,0 +1,13 @@
+package test_files
+
+import "fmt"
+
+func f() string {
+	fmt.Println("")
+	return ""
+}
+
+func main() {
+	str := f()
+	fmt.Println(str)
+}


### PR DESCRIPTION
This is a cleaner way to fix Issue #82 However, I am unable to account for what reason did
`Match` in `pos.go` originally return false in this case. By making this change, there's a risk that
I'm missing out an edge case where 
	`if !got.IsValid() && m.Pos.IsValid() {`
should return false but because of the above change would return true & give wrong result.
This passes on all the current testcases and some other tests that I tried but still a risk.

Can test by running
```
go run ./... -p testdata/patch/return_elision.patch testdata/test_files/test_return_elision.go
```